### PR TITLE
Update the POM repositories for geotools lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,15 +84,9 @@
 
 	<repositories>
 		<repository>
-			<id>maven2-repository.dev.java.net</id>
-			<name>Java.net repository</name>
-			<url>http://download.java.net/maven/2</url>
-		</repository>
-		<repository>
-			<id>osgeo</id>
-			<name>Open Source Geospatial Foundation Repository</name>
-			<url>http://download.osgeo.org/webdav/geotools/</url>
-		</repository>
+			<id>osgeo-alt</id>
+			<url>https://repo.osgeo.org/repository/release/</url>
+ 		</repository>
 	</repositories>
 
 	<build>


### PR DESCRIPTION
Solve an issue that occurs during the build process because `org.geotools:gt-api:jar:14.1` no longer exists at:

- [http://download.java.net/maven/2](http://download.java.net/maven/2)
- [http://download.osgeo.org/webdav/geotools/](http://download.osgeo.org/webdav/geotools/)

These repositories have been replaced by:

- [https://repo.osgeo.org/repository/release/](https://repo.osgeo.org/repository/release/)